### PR TITLE
feat!: Add region support

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,13 +45,13 @@ module "ram_resource_share" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.6 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 6.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 6.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.0 |
 
 ## Modules
 

--- a/README.md
+++ b/README.md
@@ -45,13 +45,13 @@ module "ram_resource_share" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.6 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.82 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 6.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.82 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 6.0 |
 
 ## Modules
 
@@ -74,6 +74,7 @@ No modules.
 | <a name="input_allow_external_principals"></a> [allow\_external\_principals](#input\_allow\_external\_principals) | Indicates whether principals outside your organization can be associated with the AWS RAM Resource Share | `bool` | `false` | no |
 | <a name="input_permission_arns"></a> [permission\_arns](#input\_permission\_arns) | Specifies the Amazon Resource Names (ARNs) of the RAM permission to associate with the AWS RAM Resource Share. If you do not specify an ARN for the permission, AWS RAM automatically attaches the default version of the permission for each resource type. | `set(string)` | `null` | no |
 | <a name="input_principals"></a> [principals](#input\_principals) | A map of keys to AWS Principals (Account ID's, OUs) to associate with the AWS RAM Resource Share | `map(string)` | `{}` | no |
+| <a name="input_region"></a> [region](#input\_region) | The AWS region where resources will be created; if omitted the default provider region is used | `string` | `null` | no |
 
 ## Outputs
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,0 +1,9 @@
+# Upgrading Notes
+
+This document captures required refactoring on your part when upgrading to a module version that contains breaking changes.
+
+## Upgrading to v2.0.0
+
+### Key Changes
+
+- This module now requires a minimum AWS provider version of 6.0 to support the `region` parameter. If you are using multiple AWS provider blocks, please read [migrating from multiple provider configurations](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/enhanced-region-support#migrating-from-multiple-provider-configurations).

--- a/examples/associate_ou/terraform.tf
+++ b/examples/associate_ou/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.0"
+      version = ">= 6.0"
     }
   }
 }

--- a/examples/associate_ou/terraform.tf
+++ b/examples/associate_ou/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.82"
+      version = "~> 6.0"
     }
   }
 }

--- a/examples/basic/terraform.tf
+++ b/examples/basic/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.0"
+      version = ">= 6.0"
     }
   }
 }

--- a/examples/basic/terraform.tf
+++ b/examples/basic/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.82"
+      version = "~> 6.0"
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,6 @@
 resource "aws_ram_resource_share" "default" {
   name                      = var.name
+  region                    = var.region
   allow_external_principals = var.allow_external_principals
   permission_arns           = var.permission_arns
 }
@@ -7,6 +8,7 @@ resource "aws_ram_resource_share" "default" {
 resource "aws_ram_resource_association" "default" {
   for_each = var.shared_resource_arns
 
+  region             = var.region
   resource_arn       = each.value
   resource_share_arn = aws_ram_resource_share.default.arn
 }
@@ -15,5 +17,6 @@ resource "aws_ram_principal_association" "default" {
   for_each = var.principals
 
   principal          = each.value
+  region             = var.region
   resource_share_arn = aws_ram_resource_share.default.arn
 }

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 resource "aws_ram_resource_share" "default" {
-  name                      = var.name
   region                    = var.region
+  name                      = var.name
   allow_external_principals = var.allow_external_principals
   permission_arns           = var.permission_arns
 }
@@ -16,7 +16,7 @@ resource "aws_ram_resource_association" "default" {
 resource "aws_ram_principal_association" "default" {
   for_each = var.principals
 
-  principal          = each.value
   region             = var.region
+  principal          = each.value
   resource_share_arn = aws_ram_resource_share.default.arn
 }

--- a/terraform.tf
+++ b/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.0"
+      version = ">= 6.0"
     }
   }
 }

--- a/terraform.tf
+++ b/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.82"
+      version = "~> 6.0"
     }
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -21,6 +21,12 @@ variable "principals" {
   description = "A map of keys to AWS Principals (Account ID's, OUs) to associate with the AWS RAM Resource Share"
 }
 
+variable "region" {
+  type        = string
+  default     = null
+  description = "The AWS region where resources will be created; if omitted the default provider region is used"
+}
+
 variable "shared_resource_arns" {
   type        = map(string)
   description = "A map of keys to Resource ARNs to associate with the AWS RAM Resource Share"


### PR DESCRIPTION
⚠️  This introduces a breaking change as it requires at least v6 of the AWS provider. ⚠️

## :hammer_and_wrench: Summary

Region configuration improvements:

- Added a new `region` variable in `variables.tf` to allow users to specify the AWS region for the RAM Resource Share and related resources. If omitted, the default provider region is used.
- Updated all resources to accept and use the region variable. This ensures consistent resource creation in the specified region.

## :rocket: Motivation

Adding `var.region` removes the need to instantiate multiple AWS provider instances for multi-region deployments and ensure compatibility with the latest AWS provider.

## :pencil: Additional Information

- [Terraform AWS Provider Version 6 Upgrade Guide](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/version-6-upgrade)
